### PR TITLE
fix: get path of conda env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/src/pyopensky/__init__.py
+++ b/src/pyopensky/__init__.py
@@ -1,5 +1,7 @@
+import os
 import sys
 from importlib.metadata import version
+from pathlib import Path
 
 from .tzdata import download_tzdata_windows
 
@@ -10,4 +12,10 @@ __version__ = version("pyopensky")
 # artifact that has been retained for compatibility with older versions of
 # Python.
 if sys.platform == "win32":
-    download_tzdata_windows(year=2022)
+    conda_env_path = os.getenv('CONDA_PREFIX', None)
+    if conda_env_path:
+        base_dir = Path(conda_env_path) / "Lib" / "site-packages" / "tzdata"
+    else:
+        base_dir = Path(os.path.expanduser("~")) / "Downloads"
+
+    download_tzdata_windows(year=2022, base_dir=base_dir)

--- a/src/pyopensky/tzdata.py
+++ b/src/pyopensky/tzdata.py
@@ -19,9 +19,14 @@ def download_tzdata_windows(
     name: str = "tzdata",
     base_dir: None | Path = None,
 ) -> None:
-    folder = (
-        base_dir if base_dir else Path(os.path.expanduser("~")) / "Downloads"
-    )
+    if base_dir is None:
+        conda_env_path = os.getenv('CONDA_PREFIX', None)
+        if conda_env_path:
+            base_dir = Path(conda_env_path) / "Lib" / "site-packages" / "tzdata"
+        else:
+            base_dir = Path(os.path.expanduser("~")) / "Downloads"
+
+    folder = base_dir
 
     if (folder / name).is_dir():
         return


### PR DESCRIPTION
When the system is win32, the package try to find tzdata.tar.gz in the "../download" (such as "C:\Users\Administrator\Downloads\") instead of the conda env. So, i try to solve the problem by setting the base_dir when sys.platform == "win32" in init.py and tzdata.py.